### PR TITLE
Allow aiops-installation configurable

### DIFF
--- a/config/3.2/cp4waiops/templates/ai-installation.yaml
+++ b/config/3.2/cp4waiops/templates/ai-installation.yaml
@@ -2,7 +2,7 @@
 apiVersion: orchestrator.aiops.ibm.com/v1alpha1
 kind: Installation
 metadata:
-  name: aiops-installation
+  name: {{.Values.spec.aiManager.instanceName}}
   namespace: {{.Values.spec.aiManager.namespace}}
   annotations:
     argocd.argoproj.io/sync-wave: "120"

--- a/config/3.2/cp4waiops/values.yaml
+++ b/config/3.2/cp4waiops/values.yaml
@@ -20,7 +20,7 @@ spec:
   ## that are associated with the entitled software.
   ## DO NOT Commit your docker password here, but always specify it in UI or CLI when creating the ArgoCD app.
   ## 
-  dockerPassword: password
+  dockerPassword: REPLACE_IT
 
   ## storageClass is the storage class that you want to use. 
   ## If the storage provider for your deployment is Red Hat OpenShift Data Foundation, 
@@ -53,6 +53,9 @@ spec:
     ## and SCCs cannot be assigned to pods created in one of the default OpenShift projects (namespaces).
     ##
     namespace: cp4waiops
+
+    ## instanceName is the Installation CR name of CP4WAIOps (AI Manager)
+    instanceName: aiops-installation
 
   eventManager:
     ## Enable Event Manager


### PR DESCRIPTION
It's common to see people use different Installation CR name. This PR is to make the Installation CR name (`aiops-installation` by default) configurable.

Also, make default value of dockerPassword more self-explained. (password -> REPLACE_IT)