### PR TITLE
Publish cp4waiops chart automatically

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'config/3.2/cp4waiops'
+
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.4.0
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.3.0
+        with:
+          version: v1.3.0
+          charts_dir: 'config/3.2/cp4waiops'
+        env:
+          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/config/3.2/cp4waiops/Chart.yaml
+++ b/config/3.2/cp4waiops/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
-name: cp4waiops-instance-3.2
-description: CP4WAIops 3.2 instance
+name: cp4waiops32
+description: Cloud Pak for Watson AIOps v3.2
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -21,4 +21,4 @@ version: 0.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.0"
+appVersion: "3.2"


### PR DESCRIPTION
Allow the helm charts of CP4WAIOps to be published and self-hosted as a helm repo using GitHub Pages. This allows the customization of CP4WAIOps deployment a lot easier when using `helm dependency` feature. For example, I can declare another helm chart somewhere else in another repo and declare to depend on the original CP4WAIOps helm chart published in this repo, so that I can customize and overwrite deployment settings based on the original one.

Using GitHub Actions make the helm charts publishing process happen automatically. Anytime when there is a merge to `main` branch, it will trigger a publishing process, the final charts will be published and available at: https://ibm.github.io/cp4waiops-gitops/.