### PR TITLE
Improve sync waves

### DIFF
--- a/ceph/storageclass-test.yaml
+++ b/ceph/storageclass-test.yaml
@@ -17,7 +17,9 @@ spec:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-   name: rook-ceph-block
+  name: rook-ceph-block
+  annotations:
+    argocd.argoproj.io/sync-wave: "1000"
 # Change "rook-ceph" provisioner prefix to match the operator namespace if needed
 provisioner: rook-ceph.rbd.csi.ceph.com  # driver:namespace:operator
 parameters:

--- a/ceph/storageclass.yaml
+++ b/ceph/storageclass.yaml
@@ -2,6 +2,9 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: rook-cephfs
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+    argocd.argoproj.io/sync-wave: "1000"
 provisioner: rook-ceph.cephfs.csi.ceph.com # driver:namespace:operator
 parameters:
   # clusterID is the namespace where operator is deployed.

--- a/config/3.2/cp4waiops/templates/check-prereqs-job.yaml
+++ b/config/3.2/cp4waiops/templates/check-prereqs-job.yaml
@@ -1,0 +1,66 @@
+{{- if eq .Values.spec.storageClass "rook-cephfs" }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: check-aiops-prereqs
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1000"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-check-aiops-prereqs
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1000"
+rules:
+- apiGroups: ["storage.k8s.io"]
+  resources:
+  - storageclass
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-check-aiops-prereqs
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1000"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-check-aiops-prereqs
+subjects:
+- kind: ServiceAccount
+  name: check-aiops-prereqs
+  namespace: {{.Values.spec.aiManager.namespace}}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-aiops-prereqs
+  annotations:
+    argocd.argoproj.io/sync-wave: "-900"
+spec:
+  template:
+    spec:
+      containers:
+        - name: check-aiops-prereqs
+          image: quay.io/openshift/origin-cli:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -x
+
+              while : ; do
+                if oc get sc -o "jsonpath={.items[*].metadata.annotations['storageclass\.kubernetes\.io/is-default-class']}" | grep -q ^true$; then
+                  echo "INFO: Default storage class available."
+                  exit 0
+                fi
+                echo "INFO: Default storage class not available, waiting."
+                sleep 10
+              done
+      restartPolicy: Never
+      serviceAccountName: check-aiops-prereqs
+  backoffLimit: 10
+{{- end }}


### PR DESCRIPTION
This PR is to improve the sync waves during the AIOps install. The `check-aiops-prereqs` job is designed to detect any prereq that's required before Argo goes to the next wave to kick off the actual AIOps install. Right now, it's used to detect the storage class availability: specifically, if storageClass is ceph, and it is defined as default storage class. This logic will only be applied when storageClass is ceph, so that will not impact other install scenarios such as using other storageClass on ROKS or AWS.