### PR TITLE
Add custom build support for cp4waiops in all-in-one chart

### DIFF
--- a/config/all-in-one/templates/_helpers.tpl
+++ b/config/all-in-one/templates/_helpers.tpl
@@ -7,6 +7,6 @@ Specify the config path
   {{- else if eq .Values.cp4waiops.version "3.3" }}
   {{- printf "config/3.3/ai-manager" -}}
   {{- else }}
-  {{- printf "config/3.3/ai-manager" -}}
+  {{- fail "The CP4WAIOps all in one chart only supports release 3.2, 3.3." }}
   {{- end }}
 {{- end -}}

--- a/config/all-in-one/templates/_helpers.tpl
+++ b/config/all-in-one/templates/_helpers.tpl
@@ -5,8 +5,8 @@ Specify the config path
   {{- if eq .Values.cp4waiops.version "3.2" }}
   {{- printf "config/3.2/cp4waiops" -}}
   {{- else if eq .Values.cp4waiops.version "3.3" }}
-  {{- printf "config/3.3" -}}
+  {{- printf "config/3.3/ai-manager" -}}
   {{- else }}
-  {{- printf "config/3.3" -}}
+  {{- printf "config/3.3/ai-manager" -}}
   {{- end }}
 {{- end -}}

--- a/config/all-in-one/templates/cluster-operator-fyre.yaml
+++ b/config/all-in-one/templates/cluster-operator-fyre.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cluster }}
 {{- if and .Values.cluster.enabled (eq .Values.cluster.provider.type "fyre") }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -24,4 +25,5 @@ spec:
     automated:
       prune: true
       selfHeal: true
+{{- end }}
 {{- end }}

--- a/config/all-in-one/templates/clusters-fyre.yaml
+++ b/config/all-in-one/templates/clusters-fyre.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cluster }}
 {{- if and .Values.cluster.enabled (eq .Values.cluster.provider.type "fyre") }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -40,4 +41,5 @@ spec:
     automated:
       prune: true
       selfHeal: true
+{{- end }}
 {{- end }}

--- a/config/all-in-one/templates/cp4waiops-config.yaml
+++ b/config/all-in-one/templates/cp4waiops-config.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.cp4waiops.enabled .Values.cp4waiops.setup }}
+{{- if .Values.cp4waiops.setup.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
@@ -30,7 +30,23 @@ spec:
         helm:
           parameters:
             - name: 'humio.enabled'
-              value: '{{ .Values.humio.enabled }}'
+              {{- if .Values.cp4waiops.setup.humio }}
+              value: {{ hasKey .Values.cp4waiops.setup.humio "enabled" | ternary .Values.cp4waiops.setup.humio.enabled true }}
+              {{- else }}
+              value: true
+              {{- end }}
+            - name: 'kafka.enabled'
+              {{- if .Values.cp4waiops.setup.kafka }}
+              value: {{ hasKey .Values.cp4waiops.setup.kafka "enabled" | ternary .Values.cp4waiops.setup.kafka.enabled true }}
+              {{- else }}
+              value: true
+              {{- end }}
+            - name: 'kube.enabled'
+              {{- if .Values.cp4waiops.setup.kubernetes }}
+              value: {{ hasKey .Values.cp4waiops.setup.kubernetes "enabled" | ternary .Values.cp4waiops.setup.kubernetes.enabled true }}
+              {{- else }}
+              value: true
+              {{- end }}
       syncPolicy:
         automated:
           prune: true

--- a/config/all-in-one/templates/cp4waiops-custom.yaml
+++ b/config/all-in-one/templates/cp4waiops-custom.yaml
@@ -25,8 +25,8 @@ spec:
       project: default
       source:
         path: config/cp4waiops-custom
-        repoURL: https://github.com/IBM/cp4waiops-gitops
-        targetRevision: HEAD
+        repoURL: https://github.com/morningspace/cp4waiops-gitops
+        targetRevision: release-3.3
         helm:
           valueFiles:
             - values.yaml

--- a/config/all-in-one/templates/cp4waiops-custom.yaml
+++ b/config/all-in-one/templates/cp4waiops-custom.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.cp4waiops.enabled (eq .Values.cp4waiops.profile "x-small") }}
+{{- if eq .Values.cp4waiops.profile "x-small" }}
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:

--- a/config/all-in-one/templates/cp4waiops-custom.yaml
+++ b/config/all-in-one/templates/cp4waiops-custom.yaml
@@ -25,8 +25,8 @@ spec:
       project: default
       source:
         path: config/cp4waiops-custom
-        repoURL: https://github.com/morningspace/cp4waiops-gitops
-        targetRevision: release-3.3
+        repoURL: {{ default "https://github.com/IBM/cp4waiops-gitops" .Values.cp4waiops.repoURL }}
+        targetRevision: {{ default "HEAD" .Values.cp4waiops.targetRevision }}
         helm:
           valueFiles:
             - values.yaml

--- a/config/all-in-one/templates/cp4waiops.yaml
+++ b/config/all-in-one/templates/cp4waiops.yaml
@@ -52,9 +52,13 @@ spec:
             - name: spec.aiManager.channel
               value: '{{ .Values.cp4waiops.aiManager.channel }}'
             {{- end }}
-            {{- if .Values.globalImagePullSecrets }}
-            - name: globalImagePullSecrets
-              value: '{{ .Values.globalImagePullSecrets }}'
+            {{- if .Values.dockercfg }}
+            {{- range $idx, $cfg := .Values.dockercfg }}
+            {{- range $key, $val := $cfg }}
+            - name: globalImagePullSecrets[{{ $idx }}].{{ $key }}
+              value: '{{ $val }}'
+            {{- end }}
+            {{- end }}
             {{- end }}
       ignoreDifferences:
         - group: orchestrator.aiops.ibm.com

--- a/config/all-in-one/templates/cp4waiops.yaml
+++ b/config/all-in-one/templates/cp4waiops.yaml
@@ -44,6 +44,14 @@ spec:
             - name: spec.aiManager.size
               value: '{{ .Values.cp4waiops.profile }}'
             {{- end }}
+            {{- if .Values.cp4waiops.aiManager.imageCatalog }}
+            - name: spec.imageCatalog
+              value: '{{ .Values.cp4waiops.aiManager.imageCatalog }}'
+            {{- end }}
+            {{- if .Values.cp4waiops.aiManager.channel }}
+            - name: spec.aiManager.channel
+              value: '{{ .Values.cp4waiops.aiManager.channel }}'
+            {{- end }}
       ignoreDifferences:
         - group: orchestrator.aiops.ibm.com
           jsonPointers:

--- a/config/all-in-one/templates/cp4waiops.yaml
+++ b/config/all-in-one/templates/cp4waiops.yaml
@@ -25,8 +25,8 @@ spec:
       project: default
       source:
         path: {{ template "cp4waiops.configPath" . }}
-        repoURL: https://github.com/IBM/cp4waiops-gitops
-        targetRevision: HEAD
+        repoURL: https://github.com/morningspace/cp4waiops-gitops
+        targetRevision: release-3.3
         helm:
           parameters:
             - name: spec.dockerUsername

--- a/config/all-in-one/templates/cp4waiops.yaml
+++ b/config/all-in-one/templates/cp4waiops.yaml
@@ -52,8 +52,8 @@ spec:
             - name: spec.aiManager.channel
               value: '{{ .Values.cp4waiops.aiManager.channel }}'
             {{- end }}
-            {{- if .Values.dockercfg }}
-            {{- range $idx, $cfg := .Values.dockercfg }}
+            {{- if .Values.globalImagePullSecrets }}
+            {{- range $idx, $cfg := .Values.globalImagePullSecrets }}
             {{- range $key, $val := $cfg }}
             - name: globalImagePullSecrets[{{ $idx }}].{{ $key }}
               value: '{{ $val }}'

--- a/config/all-in-one/templates/cp4waiops.yaml
+++ b/config/all-in-one/templates/cp4waiops.yaml
@@ -52,6 +52,10 @@ spec:
             - name: spec.aiManager.channel
               value: '{{ .Values.cp4waiops.aiManager.channel }}'
             {{- end }}
+            {{- if .Values.globalImagePullSecrets }}
+            - name: globalImagePullSecrets
+              value: '{{ .Values.globalImagePullSecrets }}'
+            {{- end }}
       ignoreDifferences:
         - group: orchestrator.aiops.ibm.com
           jsonPointers:

--- a/config/all-in-one/templates/cp4waiops.yaml
+++ b/config/all-in-one/templates/cp4waiops.yaml
@@ -24,8 +24,8 @@ spec:
       project: default
       source:
         path: {{ template "cp4waiops.configPath" . }}
-        repoURL: https://github.com/morningspace/cp4waiops-gitops
-        targetRevision: release-3.3
+        repoURL: {{ default "https://github.com/IBM/cp4waiops-gitops" .Values.cp4waiops.repoURL }}
+        targetRevision: {{ default "HEAD" .Values.cp4waiops.targetRevision }}
         helm:
           parameters:
             - name: spec.dockerUsername

--- a/config/all-in-one/templates/cp4waiops.yaml
+++ b/config/all-in-one/templates/cp4waiops.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.cp4waiops.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
@@ -75,4 +74,3 @@ spec:
           selfHeal: true
         syncOptions:
           - CreateNamespace=true
-{{- end }}

--- a/config/all-in-one/templates/resource-locker.yaml
+++ b/config/all-in-one/templates/resource-locker.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.robotshop.enabled .Values.humio.enabled (and .Values.cp4waiops.enabled (eq .Values.cp4waiops.profile "x-small")) }}
+{{- if or .Values.robotshop.enabled .Values.humio.enabled (eq .Values.cp4waiops.profile "x-small") }}
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:

--- a/config/all-in-one/values.yaml
+++ b/config/all-in-one/values.yaml
@@ -18,24 +18,24 @@ argocd:
 # -----------------------------------------------------------------------------
 # Cluster parameters
 # -----------------------------------------------------------------------------
-cluster:
-
-  # Specify whether or not to provision a cluster before install CP4WAIOps.
-  enabled: false
-
-  # Provider specific configuration
-  provider:
-    # Fyre configuration
-    # NOTE: Fyre is an internal used IaaS platform for IBM
-    type: fyre
-    # Fyre credentials
-    credentials:
-      # Fyre user id required when calling Fyre API
-      user: REPLACE_IT
-      # Fyre user token required when calling Fyre API
-      token: REPLACE_IT
-      # Fyre product group id required when calling Fyre API
-      productGroupId: REPLACE_IT
+# cluster:
+#
+#   # Specify whether or not to provision a cluster before install CP4WAIOps.
+#   enabled: false
+#
+#   # Provider specific configuration
+#   provider:
+#     # Fyre configuration
+#     # NOTE: Fyre is an internal used IaaS platform for IBM
+#     type: fyre
+#     # Fyre credentials
+#     credentials:
+#       # Fyre user id required when calling Fyre API
+#       user: REPLACE_IT
+#       # Fyre user token required when calling Fyre API
+#       token: REPLACE_IT
+#       # Fyre product group id required when calling Fyre API
+#       productGroupId: REPLACE_IT
 
 # -----------------------------------------------------------------------------
 # Storage parameters
@@ -49,9 +49,6 @@ rookceph:
 # CP4WAIOps parameters
 # -----------------------------------------------------------------------------
 cp4waiops:
-
-  # Specify whether or not to install CP4WAIOps.
-  enabled: true
 
   # Specify the version of CP4WAIOps, e.g.: 3.2, 3.3.
   version: "3.3"
@@ -74,9 +71,20 @@ cp4waiops:
     # The namespace of CP4WAIOps.
     namespace: cp4waiops
 
-  # Specify whether or not to setup CP4WAIOps with sample integrations, e.g.:
-  # Humio, Kafka, Kubernetes, etc. after it is installed.
-  setup: true
+  # Setup CP4WAIOps after installed
+  setup:
+    # Specify whether or not to setup CP4WAIOps with sample integrations, e.g.:
+    # Humio, Kafka, Kubernetes, etc. after it is installed.
+    enabled: false
+    # Setup Humio integration
+    # humio:
+    #   enabled: false
+    # Setup Kafka integration
+    # kafka:
+    #   enabled: false
+    # Setup Kubernetes integration
+    # kubernetes:
+    #   enabled: false
 
 # -----------------------------------------------------------------------------
 # Robotshop parameters
@@ -84,7 +92,7 @@ cp4waiops:
 robotshop:
 
   # Specify whether or not to install Robotshop.
-  enabled: true
+  enabled: false
 
 # -----------------------------------------------------------------------------
 # Humio parameters
@@ -92,7 +100,7 @@ robotshop:
 humio:
 
   # Specify whether or not to install Humio.
-  enabled: true
+  enabled: false
 
 # -----------------------------------------------------------------------------
 # Istio parameters
@@ -100,4 +108,4 @@ humio:
 istio:
 
   # Specify whether or not to install Istio.
-  enabled: true
+  enabled: false

--- a/config/all-in-one/values.yaml
+++ b/config/all-in-one/values.yaml
@@ -54,7 +54,7 @@ cp4waiops:
   enabled: true
 
   # Specify the version of CP4WAIOps, e.g.: 3.2, 3.3.
-  version: "3.2"
+  version: "3.3"
 
   # The username of image registry used to pull CP4WAIOps images.
   dockerUsername: cp

--- a/config/cp4waiops-custom/values.x-small.yaml
+++ b/config/cp4waiops-custom/values.x-small.yaml
@@ -112,7 +112,7 @@ res:
         memory: 1280Mi
       requests:
         cpu: 250m
-        memory: 1024Mi
+        memory: 1280Mi
     jobManager:
       limits:
         cpu: 600m

--- a/config/cp4waiops-custom/values.x-small.yaml
+++ b/config/cp4waiops-custom/values.x-small.yaml
@@ -112,7 +112,7 @@ res:
         memory: 1280Mi
       requests:
         cpu: 250m
-        memory: 768Mi
+        memory: 1024Mi
     jobManager:
       limits:
         cpu: 600m


### PR DESCRIPTION
This PR supports cp4waiops install using custom build. It allows user to:

- Specify custom build by providing catalog image and channel name using "implicit" helm params to override the default GA build, in below format:

```yaml
cp4waiops:
  aiManager:
    imageCatalog: <image_catalog>
    channel: <channel>
```

- Specify arbitrary number of container registries using "implicit" helm params, in below format:

```yaml
globalImagePullSecrets:
- registry: <registry1>
  username: <username1>
  password: <password1>
- registry: <registry2>
  username: <username2>
  password: <password3>
```