### PR TITLE
WIP Add delete script task

### DIFF
--- a/config/3.3/ai-manager/templates/check-object-job.yaml
+++ b/config/3.3/ai-manager/templates/check-object-job.yaml
@@ -17,10 +17,10 @@ spec:
               set -x
               while : ; do
                 if oc get Object; then
-                  echo "INFO: Crossplane kubernetes provider available."
+                  echo "INFO: Crossplane provider kubernetes available."
                   exit 0
                 fi
-                  echo "INFO: Crossplane kubernetes provider not available, waiting."
+                  echo "INFO: Crossplane provider kubernetes not available, waiting ..."
                   sleep 10
               done
       restartPolicy: Never

--- a/config/3.3/ai-manager/templates/check-object-job.yaml
+++ b/config/3.3/ai-manager/templates/check-object-job.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: check-object-prereqs
+  annotations:
+    argocd.argoproj.io/sync-wave: "200"
+spec:
+  template:
+    spec:
+      containers:
+        - name: check-object-prereqs
+          image: quay.io/openshift/origin-cli:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -x
+              while : ; do
+                if oc get Object; then
+                  echo "INFO: Crossplane kubernetes provider available."
+                  exit 0
+                fi
+                  echo "INFO: Crossplane kubernetes provider not available, waiting."
+                  sleep 10
+              done
+      restartPolicy: Never
+      serviceAccountName: openshift-argocd-admin-ai
+  backoffLimit: 10

--- a/config/3.3/ai-manager/templates/object.yaml
+++ b/config/3.3/ai-manager/templates/object.yaml
@@ -1,0 +1,127 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-crossplane-kubernetes-provider
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  finalizers:
+    - rbac.authorization.k8s.io/deleting
+rules:
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  verbs: ["get", "list", "watch", "create", "delete", "update","patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-crossplane-kubernetes-provider
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  finalizers:
+    - rbac.authorization.k8s.io/deleting
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-crossplane-kubernetes-provider
+subjects:
+  - kind: ServiceAccount
+    name: ibm-crossplane-provider-kubernetes
+    namespace: ibm-common-services
+---
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: Object
+metadata:
+  name: aiops-delete-script
+  annotations:
+    kubernetes.crossplane.io/managementType: Undeletable
+    argocd.argoproj.io/sync-wave: "300"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  # Use management policy ObserveDelete to observe or delete k8s resource,
+  # but leave to third party to create or update the resource
+  forProvider:
+    manifest:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: aiops-delete-script
+        namespace: {{.Values.spec.aiManager.namespace}}
+        finalizers:
+          - apps/deleting
+      spec:
+        selector:
+          matchLabels:
+            app: deleting
+        template:
+          metadata:
+            labels:
+              app: deleting
+          spec:
+            containers:
+              - name: deleting
+                image: quay.io/openshift/origin-cli:latest
+                imagePullPolicy: IfNotPresent
+                resources:
+                  requests:
+                    memory: "500Mi"
+                    cpu: "500m"
+                  limits:
+                    memory: "500Mi"
+                    cpu: "500m"
+                env:
+                  - name: installation_name
+                    value: {{.Values.spec.aiManager.instanceName}}
+                  - name: installation_namespace
+                    value: {{.Values.spec.aiManager.namespace}}
+                  - name: release_name
+                    value: {{ .Release.Name }}
+                  - name: channel
+                    value: {{.Values.spec.aiManager.channel}}
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+
+                    echo "AIManager wait to be deleted..."
+
+                    while true; do 
+                      status=`oc get Installation $installation_name -n $installation_namespace -o "jsonpath={.metadata.deletionTimestamp}"`
+                      if [ "${status}" != "" ]; then
+                        echo "AIManager deleting........"
+                        curl https://codeload.github.com/IBM/cp4waiops-samples/tar.gz/main | tar -xz --strip=2 cp4waiops-samples-main/uninstall
+                        version=(${channel//v/})
+                        cd $version
+                        sed -i 's/CP4WAIOPS_PROJECT="cp4waiops"/CP4WAIOPS_PROJECT="$installation_namespace"/g' uninstall-cp4waiops.props
+                        sed -i 's/INSTALLATION_NAME="ibm-cp-watson-aiops"/INSTALLATION_NAME="$installation_name"/g' uninstall-cp4waiops.props
+                        echo y | ./uninstall-cp4waiops.sh
+                        break
+                      else
+                        sleep 10s
+                      fi
+                    done
+
+                    oc patch deployment/aiops-delete-script \
+                    --type json \
+                    --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]'
+
+                    oc patch ClusterRoleBinding/$release_name-crossplane-kubernetes-provider \
+                    --type json \
+                    --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]'
+
+                    oc patch ClusterRole/$release_name-crossplane-kubernetes-provider \
+                    --type json \
+                    --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]'
+
+                    echo "end"
+
+                    while true; do 
+                      echo "Waitting to be deleted......"
+                      sleep 30s
+                    done
+
+            restartPolicy: Always
+            serviceAccountName: openshift-argocd-admin-ai
+  providerConfigRef:
+    name: kubernetes-provider

--- a/config/3.3/ai-manager/templates/object.yaml
+++ b/config/3.3/ai-manager/templates/object.yaml
@@ -87,7 +87,13 @@ spec:
 
                     echo "AIManager wait to be deleted..."
 
-                    while true; do 
+                    while true; do
+
+                      if oc get Installation $installation_name -n $installation_namespace; then
+                        echo "INFO: Installation CR not found."
+                        break
+                      fi
+
                       status=`oc get Installation $installation_name -n $installation_namespace -o "jsonpath={.metadata.deletionTimestamp}"`
                       if [ "${status}" != "" ]; then
                         echo "AIManager deleting........"

--- a/config/3.3/ai-manager/templates/object.yaml
+++ b/config/3.3/ai-manager/templates/object.yaml
@@ -83,6 +83,7 @@ spec:
                   - /bin/sh
                   - -c
                   - |
+                    set -x
 
                     echo "AIManager wait to be deleted..."
 

--- a/config/3.3/ai-manager/templates/object.yaml
+++ b/config/3.3/ai-manager/templates/object.yaml
@@ -89,11 +89,6 @@ spec:
 
                     while true; do
 
-                      if oc get Installation $installation_name -n $installation_namespace; then
-                        echo "INFO: Installation CR not found."
-                        break
-                      fi
-
                       status=`oc get Installation $installation_name -n $installation_namespace -o "jsonpath={.metadata.deletionTimestamp}"`
                       if [ "${status}" != "" ]; then
                         echo "AIManager deleting........"

--- a/config/3.3/ai-manager/templates/object.yaml
+++ b/config/3.3/ai-manager/templates/object.yaml
@@ -39,8 +39,6 @@ metadata:
     argocd.argoproj.io/sync-wave: "300"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  # Use management policy ObserveDelete to observe or delete k8s resource,
-  # but leave to third party to create or update the resource
   forProvider:
     manifest:
       apiVersion: apps/v1
@@ -119,7 +117,7 @@ spec:
                     echo "end"
 
                     while true; do 
-                      echo "Waitting to be deleted......"
+                      echo "Waiting to be deleted ..."
                       sleep 30s
                     done
 


### PR DESCRIPTION
Add delete script task:
 - check-object-prereqs job: After `Installation CR` deployed successfully, check whether Crossplane has been deployed by common services.
 - Object: Create a deployment containing a delete script, which will not be controlled by Gitops.
 - The `check-object-prereqs` job and `Object` will be deleted by Argocd when the argocd application is deleted. The left deployment will check the Installation CR for a `deletionTimestamp`, and if so will start the delete script.
 - Add `finalizers` to avoid deleting deployments when argocd deleting AIManager namespace. When the script finishes running, it removes these "finalizers"
 - The uninstall process is often blocked by installation CR because it cannot be removed successfully, which is the biggest problem facing now. （Even if run the delete script manually）