### PR TITLE
Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents generated with [DocToc](https://github.com/thlorenz/doctoc)*
+**Table of Contents** *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Deploy Cloud Pak for Watson AIOps using GitOps](#deploy-cloud-pak-for-watson-aiops-using-gitops)
   - [Install CP4WAIOps using GitOps](#install-cp4waiops-using-gitops)

--- a/README.md
+++ b/README.md
@@ -1,37 +1,36 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+**Table of Contents generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Deploy Cloud Pak for Watson AIOps using GitOps](#deploy-cloud-pak-for-watson-aiops-using-gitops)
-  - [Supported CP4WAIOps Versions](#supported-cp4waiops-versions)
   - [Install CP4WAIOps using GitOps](#install-cp4waiops-using-gitops)
-  - [More Install Options for CP4WAIOps using GitOps](#more-install-options-for-cp4waiops-using-gitops)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Deploy IBM Cloud Pak for Watson AIOps using GitOps
 
-This repository is about using OpenShift GitOps to deployCloud Pak for Watson AIOps(CP4WAIOps) on Red Hat OpenShift Cluster. Refer to our [gitops webpage](https://ibm.github.io/cp4waiops-gitops/docs/) to check detailed document and start your toturial with gitops.
+This repository facilitates the use of Red Hat OpenShift GitOps to deploy Cloud Pak for Watson AIOps on a Red Hat OpenShift cluster. Refer to our [GitOps webpage](https://ibm.github.io/cp4waiops-gitops/docs/) for instructions on deploying IBM Cloud Pak for Watson AIOps with GitOps.
 
-## Supported CP4WAIOps Versions
-
-- [3.1](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.1.0) - NON OFFICIAL GITOPS RELEASE, NO OFFICIAL SUPPORT
+## Install Cloud Pak for Watson AIOps using GitOps
+<!--- [3.1](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.1.0) - NON OFFICIAL GITOPS RELEASE, NO OFFICIAL SUPPORT
 - [3.2](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.2.0) - NON OFFICIAL GITOPS RELEASE, NO OFFICIAL SUPPORT
 - [3.3](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.3.0) - TECHNICAL PREVIEW FEATURE
 - [3.4](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.4.0) - TECHNICAL PREVIEW FEATURE
 - [3.5](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.5.0) - Official Support
+-->
 
-## Install CP4WAIOps using GitOps
+[Cloud Pak for Watson AIOps 3.6 online installation with GitOps](./docs/how-to-deploy-cp4waiops-36.md)
 
-Please refer to the following documents and decide how you want to deploy CP4WAIOps:
+For more information about Cloud Pak for Watson AIOps, see the [IBM Cloud Pak for Watson AIOps documentation](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.6.0).
+<!--Please refer to the following documents and decide how you want to deploy CP4WAIOps:
 
 - [NON OFFICIAL - CP4WAIOps 3.1 Online Install](./docs/how-to-deploy-cp4waiops-31.md)
 - [NON OFFICIAL - CP4WAIOps 3.2 Online Install](./docs/how-to-deploy-cp4waiops-32.md)
 - [NON OFFICIAL - CP4WAIOps 3.2 Airgap Install](./docs/how-to-deploy-airgap-32.md)
 - [CP4WAIOps 3.3 Tech Preview Online Install](./docs/how-to-deploy-cp4waiops-33.md)
 - [CP4WAIOps 3.4 and later Online Install](./docs/how-to-deploy-cp4waiops.md)
+-->
+<!--## More Install Options for CP4WAIOps using GitOps
 
-## More Install Options for CP4WAIOps using GitOps
-
-There are some advanced configuration available for CP4WAIOps to support more install scenarios. Also, as a customer, you may want to fork this repository to customize it that meets your specific needs. For more details, please refer to [Customize CP4WAIOps Install](https://github.com/IBM/cp4waiops-gitops/blob/docs/docs/cp4waiops-custom-install.md).
+There are some advanced configuration available for CP4WAIOps to support more install scenarios. Also, as a customer, you may want to fork this repository to customize it that meets your specific needs. For more details, please refer to [Customize CP4WAIOps Install](https://github.com/IBM/cp4waiops-gitops/blob/docs/docs/cp4waiops-custom-install.md).-->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents generated with [DocToc](https://github.com/thlorenz/doctoc)*
+**Table of Contents** *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Deploy IBM Cloud Pak for Watson AIOps using GitOps](#deploy-ibm-cloud-pak-for-watson-aiops-using-gitops)
   - [Use Cases](#use-cases)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,41 +2,43 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [Deploy Cloud Pak for Watson AIOps using GitOps](#deploy-cloud-pak-for-watson-aiops-using-gitops)
+- [Deploy IBM Cloud Pak for Watson AIOps using GitOps](#deploy-ibm-cloud-pak-for-watson-aiops-using-gitops)
   - [Use Cases](#use-cases)
-  - [Install CP4WAIOps using GitOps](#install-cp4waiops-using-gitops)
-  - [More Install Options for CP4WAIOps using GitOps](#more-install-options-for-cp4waiops-using-gitops)
+  - [Install Cloud Pak for Watson AIOps using GitOps](#install-cloud-pak-for-watson-aiops-using-gitops)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-# Deploy Cloud Pak for Watson AIOps using GitOps
+# Deploy IBM Cloud Pak for Watson AIOps using GitOps
 
-This repository is about using OpenShift GitOps to deployCloud Pak for Watson AIOps(CP4WAIOps) on Red Hat OpenShift Cluster.
+This repository facilitates the use of OpenShift GitOps to deploy IBM Cloud Pak for Watson AIOps on a Red Hat OpenShift Cluster.
 
 ## Use Cases
 
-- As a Cluster Admin, I want to install Cloud Pak from scratch using GitOps, and track the Cluster update via Git Commit log. (Day 1 Operation)
-- As a Cluster Admin, I want to modify, upgrade existing Cloud Pak deployment using GitOps. (Day 2 Operation)
+- As a cluster admin, I want to install Cloud Pak for Watson AIOps using GitOps, and track the cluster update with the Git commit log. (Day 1 Operation)
+<!--- As a Cluster Admin, I want to modify, upgrade existing Cloud Pak deployment using GitOps. (Day 2 Operation)
 - As a Cluster Admin, I want to have the same install experience for all Cloud Paks via GitOps. (Consistent Install Experience)
 - As a Cluster Admin, I want to install Cloud Pak in airgap environment using GitOps. (Airgap Install)
 - As a Cluster Admin, I want to provision OpenShift cluster using GitOps. (OCP Provisioning)
 - As a Cluster Admin, I want to promote Cloud Pak from development, staging, to production environment using GitOps. (Continuous Delivery)
 - As an Application Developer, I want to deploy applications to IBM Cloud Paks via GitOps. (Application Deployment)
+-->
 
 ![IBM Cloud Pak GitOps](./images/cpk-gitops.png)
 
-## Install CP4WAIOps using GitOps
+## Install Cloud Pak for Watson AIOps using GitOps
 
 Please refer to the following documents and decide how you want to deploy CP4WAIOps:
 
-- [NON OFFICIA - CP4WAIOps 3.1 Online Install](how-to-deploy-cp4waiops-31.md)
+<!-- - [NON OFFICIA - CP4WAIOps 3.1 Online Install](how-to-deploy-cp4waiops-31.md)
 - [NON OFFICIA - CP4WAIOps 3.2 Online Install](how-to-deploy-cp4waiops-32.md)
 - [NON OFFICIA - CP4WAIOps 3.2 Airgap Install](how-to-deploy-airgap-32.md)
 - [TECHNICAL PREVIEW FEATURE - CP4WAIOps 3.3 Tech Preview Online Install](how-to-deploy-cp4waiops-33.md)
 - [TECHNICAL PREVIEW FEATURE - CP4WAIOps 3.4 Tech Preview Online Install](how-to-deploy-cp4waiops-34.md)
 - [:tada::tada::tada:GA FEATURE - CP4WAIOps 3.5 Online Install:tada::tada::tada:](how-to-deploy-cp4waiops-35.md)
+-->
 - [:tada::tada::tada:GA FEATURE - CP4WAIOps 3.6 Online Install:tada::tada::tada:](how-to-deploy-cp4waiops-36.md)
 
-## More Install Options for CP4WAIOps using GitOps
+<!--## More Install Options for CP4WAIOps using GitOps
 
 There are some advanced configuration available for CP4WAIOps to support more install scenarios. Also, as a customer, you may want to fork this repository to customize it that meets your specific needs. For more details, please refer to [Customize CP4WAIOps Install](cp4waiops-custom-install.md).
+-->

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+**Table of Contents generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Deploy IBM Cloud Pak for Watson AIOps using GitOps](#deploy-ibm-cloud-pak-for-watson-aiops-using-gitops)
   - [Use Cases](#use-cases)
@@ -10,7 +10,7 @@
 
 # Deploy IBM Cloud Pak for Watson AIOps using GitOps
 
-This repository facilitates the use of OpenShift GitOps to deploy IBM Cloud Pak for Watson AIOps on a Red Hat OpenShift Cluster.
+This repository facilitates the use of Red Hat OpenShift GitOps to deploy Cloud Pak for Watson AIOps on a Red Hat OpenShift cluster.
 
 ## Use Cases
 
@@ -25,7 +25,7 @@ This repository facilitates the use of OpenShift GitOps to deploy IBM Cloud Pak 
 
 <!-- ![IBM Cloud Pak GitOps](./images/cpk-gitops.png) -->
 
-## Install Cloud Pak for Watson AIOps using GitOps
+## Installing Cloud Pak for Watson AIOps using GitOps
 
 <!-- Please refer to the following documents and decide how you want to deploy CP4WAIOps:-->
 
@@ -36,7 +36,7 @@ This repository facilitates the use of OpenShift GitOps to deploy IBM Cloud Pak 
 - [TECHNICAL PREVIEW FEATURE - CP4WAIOps 3.4 Tech Preview Online Install](how-to-deploy-cp4waiops-34.md)
 - [:tada::tada::tada:GA FEATURE - CP4WAIOps 3.5 Online Install:tada::tada::tada:](how-to-deploy-cp4waiops-35.md)
 -->
-- [:tada::tada::tada:GA FEATURE - CP4WAIOps 3.6 Online Install:tada::tada::tada:](how-to-deploy-cp4waiops-36.md)
+- [:tada::tada::tada: Cloud Pak for Watson AIOps 3.6 online installation :tada::tada::tada:](how-to-deploy-cp4waiops-36.md)
 
 <!--## More Install Options for CP4WAIOps using GitOps
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,11 +23,11 @@ This repository facilitates the use of OpenShift GitOps to deploy IBM Cloud Pak 
 - As an Application Developer, I want to deploy applications to IBM Cloud Paks via GitOps. (Application Deployment)
 -->
 
-![IBM Cloud Pak GitOps](./images/cpk-gitops.png)
+<!-- ![IBM Cloud Pak GitOps](./images/cpk-gitops.png) -->
 
 ## Install Cloud Pak for Watson AIOps using GitOps
 
-Please refer to the following documents and decide how you want to deploy CP4WAIOps:
+<!-- Please refer to the following documents and decide how you want to deploy CP4WAIOps:-->
 
 <!-- - [NON OFFICIA - CP4WAIOps 3.1 Online Install](how-to-deploy-cp4waiops-31.md)
 - [NON OFFICIA - CP4WAIOps 3.2 Online Install](how-to-deploy-cp4waiops-32.md)

--- a/docs/how-to-deploy-cp4waiops-35.md
+++ b/docs/how-to-deploy-cp4waiops-35.md
@@ -2,7 +2,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents** *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [Deploy IBM Cloud Pak for Watson AIOps 3.5 using GitOps](#deploy-cloud-pak-for-watson-aiops-35-using-gitops)
+- [Deploy Cloud Pak for Watson AIOps 3.5 using GitOps](#deploy-cloud-pak-for-watson-aiops-35-using-gitops)
   - [Prerequisites](#prerequisites)
   - [Installing Cloud Pak for Watson AIOps with the Argo CD UI](#installing-cloud-pak-for-watson-aiops-with-the-argo-cd-ui)
     - [Log in to Argo CD](#log-in-to-argo-cd)

--- a/docs/how-to-deploy-cp4waiops-35.md
+++ b/docs/how-to-deploy-cp4waiops-35.md
@@ -2,7 +2,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents** *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [Deploy Cloud Pak for Watson AIOps 3.5 using GitOps](#deploy-cloud-pak-for-watson-aiops-35-using-gitops)
+- [Deploy IBM Cloud Pak for Watson AIOps 3.5 using GitOps](#deploy-cloud-pak-for-watson-aiops-35-using-gitops)
   - [Prerequisites](#prerequisites)
   - [Installing Cloud Pak for Watson AIOps with the Argo CD UI](#installing-cloud-pak-for-watson-aiops-with-the-argo-cd-ui)
     - [Log in to Argo CD](#log-in-to-argo-cd)

--- a/docs/how-to-deploy-cp4waiops-36.md
+++ b/docs/how-to-deploy-cp4waiops-36.md
@@ -11,25 +11,22 @@
         - [Storage considerations](#storage-considerations)
         - [Obtain an entitlement key](#obtain-an-entitlement-key)
         - [Update the OpenShift Container Platform global pull secret](#update-the-openshift-container-platform-global-pull-secret)
-        - [Option 1: Installing AI Manager and Event Manager separately](#option-1-installing-ai-manager-and-event-manager-separately)
+        - [Installing AI Manager and Event Manager separately](#installing-ai-manager-and-event-manager-separately)
             - [Install shared components](#install-shared-components)
             - [Install AI Manager](#install-ai-manager)
             - [Install Event Manager](#install-event-manager)
-        - [Option 2: (**Technology preview**) Installing AI Manager and Event Manager with an all-in-one configuration](#option-2-technology-preview-installing-ai-manager-and-event-manager-with-an-all-in-one-configuration)
-            - [Installing AI Manager and Event Manager together](#installing-ai-manager-and-event-manager-together)
-            - [Installing Cloud Pak for Watson AIOps using a custom build](#installing-cloud-pak-for-watson-aiops-using-a-custom-build)
         - [Verify the Cloud Pak for Watson AIOps installation](#verify-the-cloud-pak-for-watson-aiops-installation)
         - [Access Cloud Pak for Watson AIOps](#access-cloud-pak-for-watson-aiops)
     - [Installing Cloud Pak for Watson AIOps from the command line](#install-cloud-pak-for-watson-aiops-from-the-command-line)
         - [Log in to Argo CD (CLI)](#log-in-to-argo-cd-cli)
+        - [Grant Argo CD cluster admin permission (CLI)](#grant-argo-cd-cluster-admin-permission-cli)
         - [Storage considerations (CLI)](#storage-considerations-cli)
-        - [Option 1: Install AI Manager and Event Manager Separately (CLI)](#option-1-install-ai-manager-and-event-manager-separately-cli)
-            - [Grant Argo CD cluster admin permission (CLI)](#grant-argo-cd-cluster-admin-permission-cli)
+        - [Installing AI Manager and Event Manager separately (CLI)](#installing-ai-manager-and-event-manager-separately-cli)
             - [Install shared components (CLI)](#install-shared-components-cli)
             - [Install AI Manager (CLI)](#install-ai-manager-cli)
             - [Install Event Manager (CLI)](#install-event-manager-cli)
-        - [Option 2: (**Technology preview**) Installing AI Manager and Event Manager with an all-in-one configuration (CLI)](#option-2-technology-preview-installing-ai-manager-and-event-manager-with-an-all-in-one-configuration-cli)
-        - [Verify Cloud Pak for Watson AIOps installation (CLI)](#verify-cloud-pak-for-watson-aiops-installation-cli)
+        - [Verify the Cloud Pak for Watson AIOps installation (CLI)](#verify-the-cloud-pak-for-watson-aiops-installation-cli)
+        - [Access Cloud Pak for Watson AIOps (CLI)](#access-cloud-pak-for-watson-aiops-cli)
     - [Troubleshooting](#troubleshooting)
         - [Storage](#storage)
             - [Problem](#problem)
@@ -42,17 +39,17 @@
 
 **Using GitOps to install Cloud Pak for Watson AIOps 3.6 is a GA feature!**
 
-The use of GitOps enables IBM Cloud Pak for Watson AIOps to be deployed on a Red Hat OpenShift Container Platform cluster from a Git repository, with the ArgoCD tool.
+The use of GitOps enables IBM Cloud Pak for Watson AIOps to be deployed on a Red Hat OpenShift Container Platform cluster from a Git repository, with the ArgoCD tool. Cloud Pak for Watson AIOps can be installed with the Argo CD user interface (UI), or with the Argo CD command line (CLI).
 
 For more information about GitOps, see [Understanding OpenShift GitOps](https://docs.openshift.com/container-platform/4.10/cicd/gitops/understanding-openshift-gitops.html#understanding-openshift-gitops) in the Red Hat OpenShift documentation.
 
 For more information about Argo, see the [Argo documentation](https://argo-cd.readthedocs.io/en/stable/).
 
-Cloud Pak for Watson AIOps can be installed with the Argo CD user interface (UI), or with the Argo CD command line (CLI). You can choose from two deployment options:
+<!--You can choose from two deployment options:
 
 Option 1: Install AI Manager and Event Manager separately
 
-Option 2: Install AI Manager and Event Manager with an all-in-one configuration (**Technology preview**)
+Option 2: Install AI Manager and Event Manager with an all-in-one configuration (**Technology preview**) -->
 
 ## Prerequisites
 
@@ -105,9 +102,7 @@ After the Argo CD App `argocd` is created, select the App from the Argo CD UI to
 
 ### Storage considerations
 
-If your Red Hat OpenShift cluster already has a default supported storage class, then skip this step.
-
-This tutorial uses Ceph storage for demonstration purpose. You must use a supported storage. For more information about supported storage, see [Storage Considerations](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.6.0?topic=requirements-storage).
+You must use a supported storage provider. For more information about supported storage, see [Storage Considerations](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.6.0?topic=requirements-storage). If your Red Hat OpenShift cluster already has a single default supported storage class, then skip this step.
 
 <!--If you are deploying on AWS, then EFS (Amazon Elastic File System) can be used for persistent storage. For more information, see [Getting started with Amazon Elastic File System](https://docs.aws.amazon.com/efs/latest/ug/getting-started.html) in the AWS documentation. You can also refer to the [AWS EFS storage configuration example](aws-efs-config-example.md)-->
 
@@ -122,6 +117,8 @@ If your cluster has multiple default storage classes, then you must edit your st
 ```
 oc edit sc [STORAGE-CLASS-NAME]
 ```
+
+This tutorial sets up and uses Ceph storage for demonstration purpose. 
 
 From the Argo CD UI, click `NEW APP`, input the following parameters for Ceph, and then click `CREATE`.
 
@@ -220,7 +217,7 @@ Obtain your IBM Entitled Registry key to enable your deployment to pull images f
 
 1. From the Red Hat OpenShift console, select the "Administrator" perspective, and then select "Workloads > Secrets".
 
-2. Select the project "openshift-config". (for latest version ocp, the `Show default projects` switch under `Project:` need to be enabled before selecting project.)
+2. Select the project "openshift-config". <!--(for latest version ocp, the `Show default projects` switch under `Project:` need to be enabled before selecting project.)-->
  
 3. Select the object "pull-secret".
 
@@ -239,7 +236,7 @@ Obtain your IBM Entitled Registry key to enable your deployment to pull images f
 
 For more information, see [Update the OpenShift Container Platform global pull secret](https://docs.openshift.com/container-platform/4.10/openshift_images/managing_images/using-image-pull-secrets.html) in the Red Hat OpenShift documentation.
 
-### Option 1: Installing AI Manager and Event Manager separately
+### Installing AI Manager and Event Manager separately
 
 #### Install shared components
 
@@ -276,8 +273,8 @@ Install AI Manager by using GitOps to create an Argo CD App for AI Manager. The 
     - Cluster URL: https://kubernetes.default.svc
     - Namespace: cp4waiops
 - PARAMETERS
-    - spec.storageClass: rook-cephfs  *(you must update this value to be the RWX storage class that is being used in your environment, check it with `oc get sc` command.)*
-    - spec.storageClassLargeBlock: rook-cephfs  *(you must update this value to be the RWO storage that is being used in your environment, check it with `oc get sc` command.)*
+    - spec.storageClass: rook-cephfs  *(you must update this value to be the RWX storage class that is being used in your environment. You can find this by running the command `oc get sc`.)*
+    - spec.storageClassLargeBlock: rook-cephfs  *(you must update this value to be the RWO storage that is being used in your environment. You can find this by running the command `oc get sc`.)*
     - spec.aiManager.channel: v3.6
     - spec.aiManager.size: small
     - spec.aiManager.namespace: cp4waiops
@@ -305,8 +302,8 @@ Install Event Manager by using GitOps to create an Argo CD App for Event Manager
     - Namespace: noi 
 - PARAMETERS
     - spec.imageCatalog: icr.io/cpopen/ibm-operator-catalog:latest
-    - spec.storageClass: rook-cephfs  *(you must update this value to be the RWX storage class that is being used in your environment, check it with `oc get sc` command.)*
-    - spec.storageClassLargeBlock: rook-cephfs  *(you must update this value to be the RWO storage class that is being used in your environment, check it with `oc get sc` command.)*
+    - spec.storageClass: rook-cephfs  *(you must update this value to be the RWX storage class that is being used in your environment. You can find this by running the command `oc get sc`.)*
+    - spec.storageClassLargeBlock: rook-cephfs  *(you must update this value to be the RWO storage class that is being used in your environment. You can find this by running the command `oc get sc`.)*
     - spec.eventManager.version: 1.6.6
     - spec.eventManager.clusterDomain: <domain_name>
     - spec.eventManager.channel: v1.10
@@ -324,7 +321,7 @@ Where `<domain_name>` is the domain name of the cluster where Event Manager is i
 **Note**:
 - If you use a repository that is forked from the official [Cloud Pak for Watson AIOps GitOps repository](https://github.com/IBM/cp4waiops-gitops) or a different branch, then you must update the values of the `Repository URL` and `Revision` parameters to match your repository and branch. For example, if you use `https://github.com/<myaccount>/cp4waiops-gitops` and `dev` branch, then these two parameters must be changed.
 
-### Option 2: (**Technology preview**) Installing AI Manager and Event Manager with an all-in-one configuration 
+<!--### Option 2: (**Technology preview**) Installing AI Manager and Event Manager with an all-in-one configuration 
 
 **NOTE:** This option is a technology preview, and must not be used for production systems.
 
@@ -370,7 +367,8 @@ NOTE:
 - `cp4waiops.profile` The profile `x-small` is only suitable for demonstrations and proof-of-concept deployments. Production environments must use a `small` or `large` profile.
 - `cp4waiops.eventManager.enabled` This must be false if you have a value of `x-small` for `cp4waiops.profile`, as this profile size is only suitable for deployments of AI Manager, and not for deployments of AI Manager and Event Manager.
 - `cp4waiops.eventManager.clusterDomain` This is the domain name of the cluster where Event Manager is installed. Use a fully qualified domain name (FQDN). For example, `apps.clustername.abc.xyz.com`.
-
+-->
+<!--
 #### Installing Cloud Pak for Watson AIOps using a custom build
 
 The all-in-one configuration enables a custom build of Cloud Pak for Watson AIOps to be installed by providing a specific image catalog and channel.
@@ -421,7 +419,7 @@ globalImagePullSecrets:
   username: <username_to_registry_2>
   password: <password_to_registry_2>
 ```
-
+-->
 ### Verify the Cloud Pak for Watson AIOps installation
 
 When Ceph and Cloud Pak for Watson AIOps are ready, you can see these Apps with a status of `Healthy` and `Synced` in the Argo CD UI.
@@ -606,7 +604,7 @@ Log in to the Red Hat OpenShift console, and then click the drop-down menu on th
 
 ![w](images/ocp-hub.png)
 
-Click on the `IBM Cloud Pak for Administration` link, and select `OpenShift authentication`.
+Click the `IBM Cloud Pak for Administration` link, and select `OpenShift authentication`.
 
 ![w](images/cpk-hub.png)
 
@@ -630,7 +628,7 @@ Congratulations! You are ready to play with Cloud Pak for Watson AIOps!
 
 Make sure that the Argo CD CLI (`argocd` command) is installed. For more information, see the [Argo documentation](https://argo-cd.readthedocs.io/en/stable/cli_installation/).
 
-Then run the following commands to log in to Argo CD:
+Then, run the following commands to log in to Argo CD:
 
 ```sh
 argo_route=openshift-gitops-server
@@ -648,26 +646,6 @@ argo_pwd=$(oc get secret ${argo_secret} \
       --password "${argo_pwd}" \
       --insecure
 ```
-
-### Storage considerations (CLI)
-
-If your Red Hat OpenShift cluster already has a default supported storage class, then skip this step.
-
-This tutorial uses Ceph storage for demonstration purpose. You must use a supported storage. For more information about supported storage, see [Storage Considerations](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.6.0?topic=requirements-storage).
-
-To create an Argo CD App for Ceph storage, run the following command:
-
-```sh
-argocd app create ceph \
-  --sync-policy automatic \
-  --project default \
-  --repo https://github.com/IBM/cp4waiops-gitops.git \
-  --path config/ceph \
-  --revision release-3.6 \
-  --dest-namespace rook-ceph \
-  --dest-server https://kubernetes.default.svc
-```
-### Option 1: Install AI Manager and Event Manager Separately (CLI)
 
 #### Grant Argo CD cluster admin permission (CLI)
 
@@ -687,6 +665,40 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 ```
+
+### Storage considerations (CLI)
+
+You must use a supported storage provider. For more information about supported storage, see [Storage Considerations](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.6.0?topic=requirements-storage). If your Red Hat OpenShift cluster already has a single default supported storage class, then skip this step.
+
+<!--If you are deploying on AWS, then EFS (Amazon Elastic File System) can be used for persistent storage. For more information, see [Getting started with Amazon Elastic File System](https://docs.aws.amazon.com/efs/latest/ug/getting-started.html) in the AWS documentation. You can also refer to the [AWS EFS storage configuration example](aws-efs-config-example.md)-->
+
+**Note**: Multiple default storage classes cause deployment problems. Run the following command to check your cluster's storage class.
+
+```bash
+oc get sc
+```
+
+If your cluster has multiple default storage classes, then you must edit your storage classes to leave only one storage class as the default. To remove the default setting from a storage class, run the following command to edit the storage class, and then delete the `storageclass.kubernetes.io/is-default-class: "true"` line under `annotations`.
+
+```
+oc edit sc [STORAGE-CLASS-NAME]
+```
+
+This tutorial sets up and uses Ceph storage for demonstration purpose. 
+
+To create an Argo CD App for Ceph storage, run the following command:
+
+```sh
+argocd app create ceph \
+  --sync-policy automatic \
+  --project default \
+  --repo https://github.com/IBM/cp4waiops-gitops.git \
+  --path config/ceph \
+  --revision release-3.6 \
+  --dest-namespace rook-ceph \
+  --dest-server https://kubernetes.default.svc
+```
+### Installing AI Manager and Event Manager separately (CLI)
 
 #### Install shared components (CLI)
 
@@ -728,7 +740,7 @@ argocd app create aimanager-app \
       --helm-set spec.aiManager.pakModules.connection.enabled=true
 ```
 
-**Important**: You must update the values of spec.storageClass and storageClassLargeBlock to be the RWX and RWO storage classes that are being used in your environment. You can check this by running `oc get sc`.
+**Important**: You must update the values of spec.storageClass and storageClassLargeBlock to be the RWX and RWO storage classes that are being used in your environment. You can find this by running the command `oc get sc`.
 
 #### Install Event Manager (CLI)
 
@@ -754,7 +766,7 @@ argocd app create eventmanager-app \
 ```
 
 **Important**:
-- You must update the values of spec.storageClass and storageClassLargeBlock to be the RWX and RWO storage classes that are being used in your environment. You can check this by running `oc get sc`.
+- You must update the values of spec.storageClass and storageClassLargeBlock to be the RWX and RWO storage classes that are being used in your environment. You can find this by running the command `oc get sc`.
 - `<domain_name>` must be the domain name of the cluster where Event Manager is installed. Use a fully qualified domain name (FQDN). For example, `apps.clustername.abc.xyz.com`. You can also retrieve the FDQN by running the following command:
 
   ```bash
@@ -762,7 +774,7 @@ argocd app create eventmanager-app \
   appDomain=`oc -n ${INGRESS_OPERATOR_NAMESPACE} get ingresscontrollers default -o json | python -c "import json,sys;obj=json.load(sys.stdin);print obj['status']['domain'];"`
   echo ${appDomain}
   ```
-
+<!--
 ### Option 2: (**Technology preview**) Installing AI Manager and Event Manager with an all-in-one configuration (CLI)
 
 **NOTE:** This option is a technology preview, and must not be used for production systems.
@@ -795,7 +807,7 @@ NOTE:
 - `cp4waiops.profile` The profile `x-small` is only suitable for demonstrations and proof-of-concept deployments. Production environments must use a `small` or `large` profile.
 - `cp4waiops.eventManager.enabled` This must be false if you have a value of `x-small` for `cp4waiops.profile`, as this profile size is only suitable for deployments of AI Manager, and not for deployments of AI Manager and Event Manager.
 - `cp4waiops.eventManager.clusterDomain` This is the domain name of the cluster where Event Manager is installed. Use a fully qualified domain name (FQDN). For example, `apps.clustername.abc.xyz.com`.
-
+-->
 ### Verify Cloud Pak for Watson AIOps installation (CLI)
 
 Run the following command to verify that the Cloud Pak for Watson AIOps installation was successful:
@@ -821,6 +833,32 @@ Wait for a while and then run the following commands to verify that all of the p
 oc get pod -n cp4waiops
 oc get pod -n noi
 ```
+
+### Access Cloud Pak for Watson AIOps (CLI)
+
+If all of the pods for Cloud Pak for Watson AIOps are up and running, then you can log in to the Cloud Pak for Watson AIOps UI as follows.
+
+Log in to the Red Hat OpenShift console, and then click the drop-down menu on the upper right.
+
+![w](images/ocp-hub.png)
+
+Click the `IBM Cloud Pak for Administration` link, and select `OpenShift authentication`.
+
+![w](images/cpk-hub.png)
+
+Log in to `IBM Cloud Pak for Administration`, click the drop-down menu on the upper right, and then select `IBM Automation (cp4waiops)`.
+
+![w](images/cpk-hub-ui.png)
+
+Log in to the Cloud Pak for Watson AIOps UI and then select `OpenShift authentication`.
+
+![w](images/cp4waiops.png)
+
+The Cloud Pak for Watson AIOps user interface is displayed.
+
+![w](images/cp4waiops-ui.png)
+
+Congratulations! You are ready to play with Cloud Pak for Watson AIOps!
 
 ## Troubleshooting
 

--- a/docs/how-to-deploy-cp4waiops-36.md
+++ b/docs/how-to-deploy-cp4waiops-36.md
@@ -732,7 +732,7 @@ oc create secret docker-registry ibm-entitlement-key \
     --namespace=cp4waiops
 ```
 
-Where <entitlement-key> is the entitlement key that you copied in the previous step.
+Where `<entitlement-key>` is the entitlement key that you copied in the previous step.
 
 ### Installing AI Manager and Event Manager separately (CLI)
 

--- a/docs/how-to-deploy-cp4waiops-36.md
+++ b/docs/how-to-deploy-cp4waiops-36.md
@@ -81,8 +81,7 @@ From the Red Hat OpenShift console, go to `User Management` > `RoleBindings` > `
     - Name: argocd-admin  
 - Role  
     - Role Name: cluster-admin  
-- Subject  
-    - ServiceAccount: check it  
+- Subject > ServiceAccount
     - Subject namespace: openshift-gitops  
     - Subject name: openshift-gitops-argocd-application-controller  
 
@@ -110,7 +109,7 @@ If your Red Hat OpenShift cluster already has a default supported storage class,
 
 This tutorial uses Ceph storage for demonstration purpose. You must use a supported storage. For more information about supported storage, see [Storage Considerations](https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.6.0?topic=requirements-storage).
 
-If you are deploying on AWS, then EFS (Amazon Elastic File System) can be used for persistent storage. For more information, see [Getting started with Amazon Elastic File System](https://docs.aws.amazon.com/efs/latest/ug/getting-started.html) in the AWS documentation. You can also refer to the [AWS EFS storage configuration example](aws-efs-config-example.md)
+<!--If you are deploying on AWS, then EFS (Amazon Elastic File System) can be used for persistent storage. For more information, see [Getting started with Amazon Elastic File System](https://docs.aws.amazon.com/efs/latest/ug/getting-started.html) in the AWS documentation. You can also refer to the [AWS EFS storage configuration example](aws-efs-config-example.md)-->
 
 **Note**: Multiple default storage classes cause deployment problems. Run the following command to check your cluster's storage class.
 
@@ -151,7 +150,7 @@ The filters on the left can be used to filter out resources. Click a resource to
 Run the following command from the command line to check that none of the pods have an error status.
 
 ```console
-[root@xyz.test.cp.fyre.ibm.com ~]# kubectl get po -n rook-ceph
+[root@xyz.test.cp.fyre.ibm.com ~]# oc get po -n rook-ceph
 NAME                                                              READY   STATUS      RESTARTS   AGE
 csi-cephfsplugin-7b6jk                                            3/3     Running     0          2d
 csi-cephfsplugin-l7mvz                                            3/3     Running     0          2d
@@ -196,7 +195,7 @@ rook-ceph-osd-prepare-worker4.body.cp.fyre.ibm.com-dxcm5          0/1     Comple
 rook-ceph-osd-prepare-worker5.body.cp.fyre.ibm.com-jclnq          0/1     Completed   0          4h16m
 ```
 
-If any of the pods are in an error state, you can check the logs by using `kubectl logs`.
+If any of the pods are in an error state, you can check the logs by using `oc logs`.
 
 ### Obtain an entitlement key
 
@@ -318,7 +317,7 @@ Where `<domain_name>` is the domain name of the cluster where Event Manager is i
 
   ```bash
   INGRESS_OPERATOR_NAMESPACE=openshift-ingress-operator
-  appDomain=`kubectl -n ${INGRESS_OPERATOR_NAMESPACE} get ingresscontrollers default -o json | python -c "import json,sys;obj=json.load(sys.stdin);print obj['status']['domain'];"`
+  appDomain=`oc -n ${INGRESS_OPERATOR_NAMESPACE} get ingresscontrollers default -o json | python -c "import json,sys;obj=json.load(sys.stdin);print obj['status']['domain'];"`
   echo ${appDomain}
   ```
 
@@ -440,7 +439,7 @@ You can check the topology of Cloud Pak for Watson AIOps from the Argo CD UI as 
 You can also check your Cloud Pak for Watson AIOps installation from the command line. For example, to check the AI Manager pods, run the following command:
 
 ```console
-[root@api.body.cp.fyre.ibm.com ~]# kubectl get po -n cp4waiops
+[root@api.body.cp.fyre.ibm.com ~]# oc get po -n cp4waiops
 NAME                                                              READY   STATUS      RESTARTS   AGE
 aimanager-aio-ai-platform-api-server-7c877989d6-7jh55             1/1     Running     0          47h
 aimanager-aio-change-risk-654884bd8c-6xpxw                        1/1     Running     0          47h
@@ -597,7 +596,7 @@ zen-pre-requisite-job-2klrt                                       0/1     Comple
 zen-watcher-d8b795b46-2q6zx                                       1/1     Running     0          47h
 ```
 
-If any pods are in an error state, you can check the logs from the Argo CD UI, or you can run `kubectl logs` from the command line.
+If any pods are in an error state, you can check the logs from the Argo CD UI, or you can run `oc logs` from the command line.
 
 ### Access Cloud Pak for Watson AIOps
 
@@ -638,10 +637,10 @@ argo_route=openshift-gitops-server
 argo_secret=openshift-gitops-cluster
 sa_account=openshift-gitops-argocd-application-controller
 
-argo_pwd=$(kubectl get secret ${argo_secret} \
+argo_pwd=$(oc get secret ${argo_secret} \
             -n openshift-gitops \
             -o jsonpath='{.data.admin\.password}' | base64 -d ; echo ) \
-&& argo_url=$(kubectl get route ${argo_route} \
+&& argo_url=$(oc get route ${argo_route} \
                -n openshift-gitops \
                -o jsonpath='{.spec.host}') \
 && argocd login "${argo_url}" \
@@ -760,7 +759,7 @@ argocd app create eventmanager-app \
 
   ```bash
   INGRESS_OPERATOR_NAMESPACE=openshift-ingress-operator
-  appDomain=`kubectl -n ${INGRESS_OPERATOR_NAMESPACE} get ingresscontrollers default -o json | python -c "import json,sys;obj=json.load(sys.stdin);print obj['status']['domain'];"`
+  appDomain=`oc -n ${INGRESS_OPERATOR_NAMESPACE} get ingresscontrollers default -o json | python -c "import json,sys;obj=json.load(sys.stdin);print obj['status']['domain'];"`
   echo ${appDomain}
   ```
 
@@ -802,13 +801,13 @@ NOTE:
 Run the following command to verify that the Cloud Pak for Watson AIOps installation was successful:
 
 ```sh
-kubectl get application -A
+oc get application -A
 ```
 
 Example output from a successful installation:
 
 ```console
-# kubectl get application -A
+# oc get application -A
 NAMESPACE          NAME                      SYNC STATUS   HEALTH STATUS
 openshift-gitops   cp4waiops                 Synced        Healthy
 openshift-gitops   in-cluster-aimanager      Synced        Healthy
@@ -819,8 +818,8 @@ openshift-gitops   in-cluster-rook-ceph      Synced        Healthy
 Wait for a while and then run the following commands to verify that all of the pods in the `cp4waiops` and `noi` namespaces are running.
 
 ```
-kubectl get pod -n cp4waiops
-kubectl get pod -n noi
+oc get pod -n cp4waiops
+oc get pod -n noi
 ```
 
 ## Troubleshooting

--- a/docs/how-to-deploy-cp4waiops-36.md
+++ b/docs/how-to-deploy-cp4waiops-36.md
@@ -21,6 +21,8 @@
         - [Log in to Argo CD (CLI)](#log-in-to-argo-cd-cli)
         - [Grant Argo CD cluster admin permission (CLI)](#grant-argo-cd-cluster-admin-permission-cli)
         - [Storage considerations (CLI)](#storage-considerations-cli)
+        - [Obtain an entitlement key (CLI)](#obtain-an-entitlement-key-cli)
+        - [Update the OpenShift Container Platform global pull secret (CLI)](#update-the-openshift-container-platform-global-pull-secret-cli)
         - [Installing AI Manager and Event Manager separately (CLI)](#installing-ai-manager-and-event-manager-separately-cli)
             - [Install shared components (CLI)](#install-shared-components-cli)
             - [Install AI Manager (CLI)](#install-ai-manager-cli)
@@ -698,6 +700,40 @@ argocd app create ceph \
   --dest-namespace rook-ceph \
   --dest-server https://kubernetes.default.svc
 ```
+
+### Obtain an entitlement key (CLI)
+
+Obtain your IBM Entitled Registry key to enable your deployment to pull images from the IBM Entitled Registry.
+
+1. Obtain the entitlement key that is assigned to your IBMid. Log in to [MyIBM Container Software Library](https://myibm.ibm.com/products-services/containerlibrary) with the IBMid and password details that are associated with the entitled software.
+
+2. In the "Entitlement key" section, select "Copy key" to copy the entitlement key to the clipboard.
+
+3. Copy the entitlement key to a safe place so that you can use it later when you update the global pull secret for the cluster.
+
+4. (Optional) Verify the validity of the key by logging in to the IBM Entitled Registry.
+
+   Depending on the container system that you are using, you might need to use `docker login` instead of `podman login` for the following command.
+
+   ```sh
+   export IBM_ENTITLEMENT_KEY=the key from the previous steps
+   podman login cp.icr.io --username cp --password "${IBM_ENTITLEMENT_KEY:?}"
+   ```
+
+### Update the OpenShift Container Platform global pull secret (CLI)
+
+Run the following command to create the entitlement key pull secret:
+
+```
+oc create secret docker-registry ibm-entitlement-key \
+    --docker-username=cp \
+    --docker-password=<entitlement-key> \
+    --docker-server=cp.icr.io \
+    --namespace=cp4waiops
+```
+
+Where <entitlement-key> is the entitlement key that you copied in the previous step.
+
 ### Installing AI Manager and Event Manager separately (CLI)
 
 #### Install shared components (CLI)

--- a/docs/how-to-deploy-cp4waiops-36.md
+++ b/docs/how-to-deploy-cp4waiops-36.md
@@ -17,7 +17,7 @@
             - [Install Event Manager](#install-event-manager)
         - [Verify the Cloud Pak for Watson AIOps installation](#verify-the-cloud-pak-for-watson-aiops-installation)
         - [Access Cloud Pak for Watson AIOps](#access-cloud-pak-for-watson-aiops)
-    - [Installing Cloud Pak for Watson AIOps from the command line](#install-cloud-pak-for-watson-aiops-from-the-command-line)
+    - [Installing Cloud Pak for Watson AIOps from the command line](#installing-cloud-pak-for-watson-aiops-from-the-command-line)
         - [Log in to Argo CD (CLI)](#log-in-to-argo-cd-cli)
         - [Grant Argo CD cluster admin permission (CLI)](#grant-argo-cd-cluster-admin-permission-cli)
         - [Storage considerations (CLI)](#storage-considerations-cli)
@@ -213,7 +213,7 @@ Obtain your IBM Entitled Registry key to enable your deployment to pull images f
    podman login cp.icr.io --username cp --password "${IBM_ENTITLEMENT_KEY:?}"
    ```
 
-### Update the Red Hat OpenShift Container Platform global pull secret
+### Update the OpenShift Container Platform global pull secret
 
 1. From the Red Hat OpenShift console, select the "Administrator" perspective, and then select "Workloads > Secrets".
 
@@ -808,7 +808,7 @@ NOTE:
 - `cp4waiops.eventManager.enabled` This must be false if you have a value of `x-small` for `cp4waiops.profile`, as this profile size is only suitable for deployments of AI Manager, and not for deployments of AI Manager and Event Manager.
 - `cp4waiops.eventManager.clusterDomain` This is the domain name of the cluster where Event Manager is installed. Use a fully qualified domain name (FQDN). For example, `apps.clustername.abc.xyz.com`.
 -->
-### Verify Cloud Pak for Watson AIOps installation (CLI)
+### Verify the Cloud Pak for Watson AIOps installation (CLI)
 
 Run the following command to verify that the Cloud Pak for Watson AIOps installation was successful:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,19 +4,8 @@ repo_url: https://github.com/IBM/cp4waiops-gitops
 nav:
     - GitOps Install:
       - Introduction: README.md
-      - v3.3 Tech Preview:
-        - Online Install: how-to-deploy-cp4waiops-33.md
-      - v3.4 Tech Preview:
-        - Online Install: how-to-deploy-cp4waiops-34.md
-      - v3.5 Official Support:
-        - Online Install: how-to-deploy-cp4waiops-35.md
       - v3.6 Official Support:
         - Online Install: how-to-deploy-cp4waiops-36.md
-      - Advanced Install Options:
-        - Customize CP4WAIOps Install: cp4waiops-custom-install.md
-        - Deploy Demo Environment: deploy-cloudpak-with-sample-apps.md
-        - Deploy to Multiple Clusters: deploy-cloudpak-to-multiple-clusters.md
-        - Deploy with Cluster Provisioning: deploy-ocp-cloudpak-with-gitops.md
         
 theme:
     name: material


### PR DESCRIPTION
Hi @gyliu513 

Another PR for you that replaces kubectl with oc/adds in getting the entitlement key and putting it in a secret for the CLI version (please check that I've got this right)/removes the content that we discussed in issue 43196. I've also edited both the READMEs and the mkdocs.yaml to remove/comment out some of the links/content that refers to non-customer facing scenario or use cases that are not implemented yet.

I've not removed the markdown file source for the obsolete content (e.g. 33->35 installs, advanced installs etc).  I've left this for your team to do, as I think you may still want them internally/may reinstate them when they are are customer-ready. They are no longer linked to from the customer facing site though.

Please ping me with anything else that you need.